### PR TITLE
Fix and Improvement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zigzag Spiral Level Order Traversal</title>
+</head>
+<body>
+    <h1>Zigzag Spiral Level Order Traversal</h1>
+    <h2>Open the browser console to view the output</h2>
+    <script src="./zigzag-spiral-level-order-traversal.js"></script>
+</body>
+</html>

--- a/zigzag-spiral-level-order-traversal.js
+++ b/zigzag-spiral-level-order-traversal.js
@@ -11,30 +11,54 @@ Given binary tree [3,9,20,null,null,15,7],
    15   7
    
 return its zigzag level order traversal as:
-
 [
   [3],
   [20,9],
   [15,7]
 ]
+
 ====
 VIDEO EXPLANATION =  https://www.youtube.com/watch?v=4u--XDffIZM
 ====
-
 **/
 
-var zigzagLevelOrder = function(root) {
+// Binary tree as input
+const binaryTree = {
+  value: 3,
+  left: {
+     value: 20,
+     left: {
+         value: 7,
+         left: null,
+         right: null
+     },
+     right: {
+          value: 15,
+          left: null,
+          right: null
+      }
+  },
+  right: {
+      value: 9,
+      left: null,
+      right: null
+  }
+};
+
+const zigzagLevelOrder = (root) => {
     let results = [];
     const lot = (root, level) => {
         if(!root) return;
         
-        if(results[level]) results[level].push(root.val);
-        else results[level] = [root.val];
+        if(results[level]) results[level].push(root.value);
+        else results[level] = [root.value];
         
         lot(root.left, level+1);
         lot(root.right, level+1);
     }
     lot(root, 0);
-    return results.map((b,i)=>(i%2) ? b.reverse(): b);
+    return results.map((b,i)=>(i%2) ? b : b.reverse());
 };
 
+const result = zigzagLevelOrder(binaryTree);
+console.log(result);


### PR DESCRIPTION
1) Fixed output issue with zigzagLevelOrder function
    As the expected result, as mentioned above in the file was:
    [
      [3],
      [20,9],
      [15,7]
    ]
    
    The function was returning the result as:
    [
      [3],
      [9,20],
      [7,15]
    ]

2) I was struggling myself to know the input for the zigzagLevelOrder function.
    Found it at last. And wanted to contribute it. Thought it would be helpful to others.
    So I added a input variable binaryTree with the value, which is an input to zigzagLevelOrder function,
    And also consoled the result with an index.html file, so that people can just clone the repo and see the result in browser 
    console quickly and play around.

3) Update the zigzagLevelOrder function to arrow function and change var to const declaration.